### PR TITLE
Use venv from anywhere for multipriors processing (and disable conda auto-download)

### DIFF
--- a/lib/multipriors/requirements.txt
+++ b/lib/multipriors/requirements.txt
@@ -1,0 +1,6 @@
+nibabel==5.1.0
+tensorflow==2.12
+keras==2.12.0
+keras-preprocessing==1.1.2
+scikit-image==0.20
+numpy==1.23.2

--- a/roast.m
+++ b/roast.m
@@ -128,6 +128,9 @@ while indArg <= length(varargin)
         case 'multipriors'
             multipriors = varargin{indArg+1};
             indArg = indArg+2;
+        case 'multipriorsenv'
+            multipriorsEnv = varargin{indArg+1};
+            indArg = indArg+2;
         case 'meshoptions'
             meshOpt = varargin{indArg+1};
             indArg = indArg+2;
@@ -144,7 +147,7 @@ while indArg <= length(varargin)
             paddingAmt = varargin{indArg+1};
             indArg = indArg+2;
         otherwise
-            error('Supported options are: ''capType'', ''elecType'', ''elecSize'', ''elecOri'', ''T2'', ''multipriors'',''meshOptions'',''conductivities'', ''simulationTag'', ''resampling'', and ''zeroPadding''.');
+            error('Supported options are: ''capType'', ''elecType'', ''elecSize'', ''elecOri'', ''T2'', ''multipriors'',''multipriorsEnv'',''meshOptions'',''conductivities'', ''simulationTag'', ''resampling'', and ''zeroPadding''.');
     end
 end
 
@@ -464,6 +467,18 @@ else
     end
 end
 
+if ~exist('multipriorsEnv', 'var')
+    multipriorsEnv = 'multipriorsEnv';  % Default to standard env dir
+else
+    if ~ischar(multipriorsEnv)
+        error('Unrecognized option value. Please provide a valid path to python executable ''multipriorsEnv''.');
+    end
+    if exist(multipriorsEnv, 'file') ~= 2  % Check if the path exists and is a file
+        error('The specified path for ''multipriorsEnv'' is invalid or does not exist. Please enter a valid Python executable file path.');
+    end
+end
+
+
 if multipriors && ~isempty(T2)
     error('MultiPriors cannot be run with both T1 and T2 images. If you meant to use MultiPriors, please only provide T1 image with option ''multipriors'' turned on.');
 end
@@ -761,7 +776,7 @@ else
     error('Something is wrong!');
 end
 
-options = struct('configTxt',configTxt,'elecPara',elecPara,'T2',T2,'multipriors',multipriors,'meshOpt',meshOpt,'conductivities',conductivities,'uniqueTag',simTag,'resamp',doResamp,'zeroPad',paddingAmt,'isNonRAS',isNonRAS);
+options = struct('configTxt',configTxt,'elecPara',elecPara,'T2',T2,'multipriors',multipriors,'multipriorsEnv',multipriorsEnv,'meshOpt',meshOpt,'conductivities',conductivities,'uniqueTag',simTag,'resamp',doResamp,'zeroPad',paddingAmt,'isNonRAS',isNonRAS);
 
 % log tracking
 Sopt = dir([dirname filesep subjName '_*_roastOptions.mat']);
@@ -837,7 +852,7 @@ if ~strcmp(subjName,'nyhead')
             disp('======================================================')
             disp('    STEP 2 (out of 6): MULTIPRIORS SEGMENTATION ...   ')
             disp('======================================================')
-            runMultipriors(subjRasRSPD,subjRasRSPDspm);
+            runMultipriors(subjRasRSPD,subjRasRSPDspm,multipriorsEnv);
         else
             disp('======================================================')
             disp('    STEP 2 (out of 6): SPM SEGMENTATION TOUCHUP ...   ')

--- a/runMultipriors.m
+++ b/runMultipriors.m
@@ -1,5 +1,5 @@
-function runMultipriors(T1,spmOut)
-% runMultipriors(T1,spmOut)
+function runMultipriors(T1,spmOut,multipriorsEnv)
+% runMultipriors(T1,spmOut,multipriorsEnv)
 % 
 % This calls MultiPriors segmentation that is based on a deep CNN.
 % 
@@ -71,60 +71,12 @@ else
     disp(['File ' outputFileName '.gz already exists. Warping TPM skipped...']);
 end
 
-% Install miniconda and MultiPriors enviornment if it doesn't exist
 % And prepare to run MultiPriors python script
-str = computer('arch');
-switch str
-    case 'win64'
-        if ~exist('multipriorsEnv', 'dir')
-            system([pwd '\lib\multipriors\setupWindows.bat']);
-        else
-            disp('Enviornment already exist on Windows. Skipping setup...');
-        end
 
-        % Specify the path to libiomp5md.dll (duplicate)
-        dllPath = [pwd '\lib\multipriors\multipriorsENV\Library\bin\libiomp5md.dll'];
-        if exist(dllPath, 'file')
-            delete(dllPath);
-            disp('Duplicate libiomp5md.dll has been deleted');
-        end
-
-        pythonExecutable = [pwd '\lib\multipriors\multipriorsEnv\python.exe'];
-
-    case 'glnxa64'
-        setupScript = [pwd '/lib/multipriors/setupLinux.sh'];
-
-        % Grant execute permissions to the script
-        system(['chmod +x ' setupScript]);
-
-        if ~exist('multipriorsEnvLinux', 'dir')
-            system([pwd '/lib/multipriors/setupLinux.sh']);
-        else
-            disp('Enviornment already exist on Linux. Skipping setup...');
-        end
-
-        pythonExecutable = [pwd '/lib/multipriors/multipriorsEnvLinux/bin/python3'];
-
-    case 'maci64'
-        setupScript = [pwd '/lib/multipriors/setupMac.sh'];
-
-        % Grant execute permissions to the script
-        system(['chmod +x ' setupScript]);
-
-        if ~exist('multipriorsEnvMac', 'dir')
-            system([pwd '/lib/multipriors/setupMac.sh']);
-        else
-            disp('Enviornment already exist on Mac. Skipping setup...');
-        end
-
-        pythonExecutable = [pwd '/lib/multipriors/multipriorsEnvMac/bin/python3'];
-
-    otherwise
-        error('Unsupported operating system!');
-end
-
+pythonExecutable = multipriorsEnv;
 pythonScript = [pwd '/lib/multipriors/SEGMENT.py'];
 configFile = [pwd '/lib/multipriors/Segmentation_config.py'];
+
 
 T1 = ['"' T1 '"']; % To allow spaces in subject path
 


### PR DESCRIPTION
tl;dr: to get a venv with python 3.9 or 3.10 anywhere on the machine to run multipriors scripts

--- 

- Added `multipriorsEnv` option so we only have to specify where the specific virtual/conda env or whatever the preferred setup to run the multipriors python code. 

- Must specify path to python bin, otherwise won't probably work.
  - `'multipriorsEnv', '/path/to/roast-venv/bin/python'`

- `roast/lib/multipriors/requirements.txt` was created by cutting down `multipriorsEnv.yml` to a minimal version, listing only packaged that were truly used. Dependencies will be sorted out by the system. 
  - Version slightly changed from the original roast multipriorsEnv.yaml but this is because it is the only way to create a venv on a SLURM system that has specific tensorflow/keras version available.
 
 - Deleted the whole conda auto download and install because it forces the user a specific way regardless of anything.
 
- [ ] Still need to document this new option.